### PR TITLE
Let jobs finish on termination signals

### DIFF
--- a/pyres/worker.py
+++ b/pyres/worker.py
@@ -101,9 +101,9 @@ class Worker(object):
     def handle_signal(self, signum, frame):
         logger.info("Interrupted by signal %s at %s:%s in %s()" % (signum, frame.f_code.co_filename, frame.f_lineno, frame.f_code.co_name))
         if signum == signal.SIGTERM:
-            self.shutdown_all(signum, frame)
+            self.schedule_shutdown(signum, frame)
         elif signum == signal.SIGINT:
-            self.shutdown_all(signum, frame)
+            self.schedule_shutdown(signum, frame)
         elif signum == signal.SIGQUIT:
             self.schedule_shutdown(signum, frame)
         elif signum == signal.SIGUSR1:
@@ -112,7 +112,6 @@ class Worker(object):
     def shutdown_all(self, signum, frame):
         self.schedule_shutdown(signum, frame)
         self.kill_child(signum, frame)
-        self.resq.close()
 
     def schedule_shutdown(self, signum, frame):
         self._shutdown = True
@@ -161,6 +160,7 @@ class Worker(object):
             elif interval == 0:
                 self._setproctitle("Waiting")
         self.unregister_worker()
+        self.resq.close()
 
     def fork_worker(self, job):
         """Invoked by ``work`` method. ``fork_worker`` does the actual forking to create the child

--- a/pyres/worker.py
+++ b/pyres/worker.py
@@ -160,6 +160,7 @@ class Worker(object):
             elif interval == 0:
                 self._setproctitle("Waiting")
         self.unregister_worker()
+        # this may break other workers using the same connection. Added so that the remote redis will clean up.
         self.resq.close()
 
     def fork_worker(self, job):


### PR DESCRIPTION
+ use clean exits on termination signals
+ move connection close to the main loop